### PR TITLE
Change "%" op from integer to floating point

### DIFF
--- a/src/JWadhams/JsonLogic.php
+++ b/src/JWadhams/JsonLogic.php
@@ -93,7 +93,7 @@ class JsonLogic
                 return ($a <= $b) and ($b <= $c) ;
             },
             '%' => function ($a, $b) {
-                return $a % $b;
+                return fmod($a, $b);
             },
             '!!' => function ($a) {
                 return static::truthy($a);


### PR DESCRIPTION
Details are in issue #8.

If accepted, users who are expecting `{"%": [10.5, 2]}` to result in 1 instead of 0.5 will be unhappy. Hence some might consider this a breaking change instead of a bugfix. JavaScript users are already receiving float modulo values, so this would align JS and PHP in terms of features.

An alternative would be to make two new ops for `intmod` and `floatmod` for explicit behaviors.