### PR TITLE
Import compiler optimized functions for big performance gain 

### DIFF
--- a/src/JWadhams/JsonLogic.php
+++ b/src/JWadhams/JsonLogic.php
@@ -2,6 +2,11 @@
 
 namespace JWadhams;
 
+use function is_object;
+use function is_array;
+use function is_string;
+use function count;
+
 class JsonLogic
 {
     private static $custom_operations = [];


### PR DESCRIPTION
In a case where we used an excessive amount of large formulas in a script, importing these functions made a 100ms+ difference, because the engine could skip calling the internal PHP functions and directly work on opcodes. Being called in the 100.000s, this matters.

Here you can see 200ms being saved in Tideways on that project with the use function imports alone:

<img width="1125" height="604" alt="Bildschirmfoto 2025-10-21 um 11 45 25" src="https://github.com/user-attachments/assets/47a74375-4095-4248-b36e-dedf2e1edf08" />
